### PR TITLE
fix: use signal names for trap

### DIFF
--- a/patches/PR3/config.guess.patch
+++ b/patches/PR3/config.guess.patch
@@ -1,0 +1,13 @@
+diff --git a/build-aux/config.guess b/build-aux/config.guess
+index 7f76b62..9eab862 100755
+--- a/build-aux/config.guess
++++ b/build-aux/config.guess
+@@ -109,7 +109,7 @@ GUESS=
+ 
+ tmp=
+ # shellcheck disable=SC2172
+-trap 'test -z "$tmp" || rm -fr "$tmp"' 0 1 2 13 15
++trap 'test -z "$tmp" || rm -fr "$tmp"' EXIT HUP INT PIPE TERM
+ 
+ set_cc_for_build() {
+     # prevent multiple calls if $tmp is already set

--- a/patches/PR3/configure.patch
+++ b/patches/PR3/configure.patch
@@ -1,0 +1,22 @@
+diff --git a/configure b/configure
+index cf27eae..572e1ab 100755
+--- a/configure
++++ b/configure
+@@ -4266,7 +4266,7 @@ $as_echo "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
+     rm -f -r conftest* confdefs* conf$$* $ac_clean_files &&
+     exit $exit_status
+ ' 0
+-for ac_signal in 1 2 13 15; do
++for ac_signal in HUP INT PIPE TERM; do
+   trap 'ac_signal='$ac_signal'; as_fn_exit 1' $ac_signal
+ done
+ ac_signal=0
+@@ -64949,7 +64949,7 @@ $debug ||
+   : "${ac_tmp:=$tmp}"
+   { test ! -d "$ac_tmp" || rm -fr "$ac_tmp"; } && exit $exit_status
+ ' 0
+-  trap 'as_fn_exit 1' 1 2 13 15
++  trap 'as_fn_exit 1' HUP INT PIPE TERM
+ }
+ # Create a (secure) tmp directory for tmp files.
+ 

--- a/patches/PR3/install-sh.patch
+++ b/patches/PR3/install-sh.patch
@@ -1,0 +1,19 @@
+diff --git a/build-aux/install-sh b/build-aux/install-sh
+index ec298b5..b72ff7f 100755
+--- a/build-aux/install-sh
++++ b/build-aux/install-sh
+@@ -234,10 +234,10 @@ fi
+ 
+ if test -z "$dir_arg"; then
+   do_exit='(exit $ret); exit $ret'
+-  trap "ret=129; $do_exit" 1
+-  trap "ret=130; $do_exit" 2
+-  trap "ret=141; $do_exit" 13
+-  trap "ret=143; $do_exit" 15
++  trap "ret=129; $do_exit" HUP
++  trap "ret=130; $do_exit" INT
++  trap "ret=141; $do_exit" PIPE
++  trap "ret=143; $do_exit" TERM
+ 
+   # Set umask so as not to create temps with too-generous modes.
+   # However, 'strip' requires both read and write access to temps.

--- a/patches/PR3/test-driver.patch
+++ b/patches/PR3/test-driver.patch
@@ -1,0 +1,19 @@
+diff --git a/build-aux/test-driver b/build-aux/test-driver
+index 0fa6395..5574956 100755
+--- a/build-aux/test-driver
++++ b/build-aux/test-driver
+@@ -105,10 +105,10 @@ else
+ fi
+ 
+ do_exit='rm -f $log_file $trs_file; (exit $st); exit $st'
+-trap "st=129; $do_exit" 1
+-trap "st=130; $do_exit" 2
+-trap "st=141; $do_exit" 13
+-trap "st=143; $do_exit" 15
++trap "st=129; $do_exit" HUP
++trap "st=130; $do_exit" INT
++trap "st=141; $do_exit" PIPE
++trap "st=143; $do_exit" TERM
+ 
+ # Test script is run here. We create the file first, then append to it,
+ # to ameliorate tests themselves also writing to the log file. Our tests


### PR DESCRIPTION
fixes #6.

This is my first time putting together a patch fix, so please check that I've done it all right.
I'm not sure I understand what the naming convention is for patch directories (I was assuming PR indicated a particular pull request, but the existing directory numbers don't match the existing PR numbers). I just went with the next number. Let me know if that needs changing.